### PR TITLE
Add remove meeting choices

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -14,17 +14,20 @@ class MeetingsController < ApplicationController
   def create
     # client = get_google_calendar_client current_user
 
-    # Named params are retrieved form params and not meeting params. Found out through raise. Need to check with TA.
     @meeting = Meeting.new(meeting_params)
+    # Named params are retrieved form params and not meeting params. Found out through raise. Need to check with TA.
     # @meeting.location = meeting_params[:location]
     # @meeting.start_datetime = params[:date] + " " + params[:start_time]
     # @meeting.end_datetime = params[:date] + " " + params[:end_time]
+
     @meeting.user = current_user
 
+    # Removed named parameters, choices' attributes can be instatinated on line 17.
     # loop through choices hash and create new choice
     # meeting_params[:choices_attributes].each_value do |value|
     #   @meeting.choices.build(value)
     # end
+
     @meeting.save!
 
     # event = get_event(@meeting)
@@ -41,6 +44,7 @@ class MeetingsController < ApplicationController
       @meeting.update(meeting_params)
       @meeting.update(status: "ACCEPTED")
       #@meeting.update(invitee_email: meeting_params[:invitee_email], status: "ACCEPTED")
+
       client = get_google_calendar_client(@meeting.user)
       event = get_event(@meeting)
       client.insert_event('primary', event, send_updates: "all")
@@ -54,7 +58,7 @@ class MeetingsController < ApplicationController
     @meeting = Meeting.find(params[:id])
   end
 
-  # CAFFIEND CREATED ACTIONS
+  # -------------------- CAFFIEND CREATED ACTIONS --------------------
 
   # UPCOMING => GET /users/:id (As a user, I can view my upcoming meetings)
   def upcoming
@@ -116,7 +120,7 @@ class MeetingsController < ApplicationController
              choices_attributes: [:id, :start_datetime, :end_datetime, :location, :_destroy])
   end
 
-
+  # Google API Get Event Method
   def get_event meeting
     attendees = [{ email: meeting.invitee_email }] # task[:members].split(',').map{ |t| {email: t.strip} }
     event = Google::Apis::CalendarV3::Event.new({

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -108,7 +108,10 @@ class MeetingsController < ApplicationController
 
   # STRONG PARAMS
   def meeting_params
-    params.require(:meeting).permit(:date, :start_time, :end_time, :location, :invitee_email, choices_attributes: [:start_datetime, :end_datetime, :location]) # Need to require named parameters from simple form
+    params
+     .require(:meeting)
+     .permit(:date, :start_time, :end_time, :location, :invitee_email,
+             choices_attributes: [:start_datetime, :end_datetime, :location])
   end
 
 

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -38,7 +38,9 @@ class MeetingsController < ApplicationController
     @meeting = Meeting.find(params[:id])
 
     if !@meeting.invitee_email
-      @meeting.update(invitee_email: meeting_params[:invitee_email], status: "ACCEPTED")
+      @meeting.update(meeting_params)
+      @meeting.update(status: "ACCEPTED")
+      #@meeting.update(invitee_email: meeting_params[:invitee_email], status: "ACCEPTED")
       client = get_google_calendar_client(@meeting.user)
       event = get_event(@meeting)
       client.insert_event('primary', event, send_updates: "all")

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -15,16 +15,16 @@ class MeetingsController < ApplicationController
     # client = get_google_calendar_client current_user
 
     # Named params are retrieved form params and not meeting params. Found out through raise. Need to check with TA.
-    @meeting = Meeting.new()
-    @meeting.location = meeting_params[:location]
-    @meeting.start_datetime = params[:date] + " " + params[:start_time]
-    @meeting.end_datetime = params[:date] + " " + params[:end_time]
+    @meeting = Meeting.new(meeting_params)
+    # @meeting.location = meeting_params[:location]
+    # @meeting.start_datetime = params[:date] + " " + params[:start_time]
+    # @meeting.end_datetime = params[:date] + " " + params[:end_time]
     @meeting.user = current_user
 
     # loop through choices hash and create new choice
-    meeting_params[:choices_attributes].each_value do |value|
-      @meeting.choices.build(value)
-    end
+    # meeting_params[:choices_attributes].each_value do |value|
+    #   @meeting.choices.build(value)
+    # end
     @meeting.save!
 
     # event = get_event(@meeting)
@@ -110,8 +110,8 @@ class MeetingsController < ApplicationController
   def meeting_params
     params
      .require(:meeting)
-     .permit(:date, :start_time, :end_time, :location, :invitee_email,
-             choices_attributes: [:start_datetime, :end_datetime, :location])
+     .permit(:start_datetime, :end_datetime, :location, :invitee_email,
+             choices_attributes: [:id, :start_datetime, :end_datetime, :location, :_destroy])
   end
 
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,5 +15,4 @@ module ApplicationHelper
     ## pass down the link to the fields form
     link_to(name, "#", class: "add_fields", data: {id: id, fields: fields.gsub("\n", "")})
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+
+  def link_to_add_fields(name, form, association)
+    ## create a new object from the association (:choices)
+    new_object = form.object.send(association).klass.new
+
+    ## create or take the ide from the new created object
+    id = new_object.object_id
+
+    ## create the fields form
+    fields = form.fields_for(association, new_object, child_index: id) do |builder|
+      render(association.to_s.singularize + "_fields", f: builder)
+    end
+
+    ## pass down the link to the fields form
+    link_to(name, "#", class: "add_fields", data: {id: id, fields: fields.gsub("\n", "")})
+  end
+
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,12 +26,16 @@ import "bootstrap";
 import { initFlatpickr } from "../plugins/flatpickr"; // Flatpickr
 import { initUpdateNavbarOnScroll } from '../components/navbar'; //navbar.js
 import "tippy.js/dist/tippy.css";
+import { init_add_fields } from "../plugins/init_add_fields";
+import { init_remove_fields } from "../plugins/init_remove_fields";
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
   initFlatpickr(); // Flatpickr
   initUpdateNavbarOnScroll(); // navbar.js
+  init_add_fields();
+  init_remove_fields();
 });
 
 import "controllers"

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,19 +23,19 @@ import "bootstrap";
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
-import { initFlatpickr } from "../plugins/flatpickr"; // Flatpickr
+import { initFlatpickr } from "../plugins/flatpickr"; // Flatpickr for date time fields in form
 import { initUpdateNavbarOnScroll } from '../components/navbar'; //navbar.js
 import "tippy.js/dist/tippy.css";
-import { init_add_fields } from "../plugins/init_add_fields";
-import { init_remove_fields } from "../plugins/init_remove_fields";
+import { init_add_fields } from "../plugins/init_add_fields"; // Add fields in nested form
+import { init_remove_fields } from "../plugins/init_remove_fields"; //Remove fields in nested form
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
   initFlatpickr(); // Flatpickr
   initUpdateNavbarOnScroll(); // navbar.js
-  init_add_fields();
-  init_remove_fields();
+  init_add_fields(); // Add fields in nested form
+  init_remove_fields(); // Remove fields in nested form
 });
 
 import "controllers"

--- a/app/javascript/plugins/init_add_fields.js
+++ b/app/javascript/plugins/init_add_fields.js
@@ -3,13 +3,20 @@ import { initFlatpickr } from "../plugins/flatpickr";
 const init_add_fields = () => {
 
   $('.simple_form').on('click', '.add_fields', function(event) {
-    console.log("clicked!")
     var regexp, time;
+
+    // Save a unique timestamp to ensure the key of the associated array is unique.
     time = new Date().getTime();
+
+    // Create a new regular expression needed to find any instance of the `new_object.object_id` used in the fields data attribute
     regexp = new RegExp($(this).data('id'), 'g');
+
+    // Replace all instances of the `new_object.object_id` with `time`, and save markup into a variable if there's a value in `regexp`.
     $(this).before($(this).data("fields").replace(regexp, time));
     event.preventDefault();
-    return initFlatpickr(); // we need to run initFlatpickr plugin after field is added again 
+
+    // Flatpickr plugin needs to run again to capture new fields
+    return initFlatpickr();
   });
 }
 

--- a/app/javascript/plugins/init_add_fields.js
+++ b/app/javascript/plugins/init_add_fields.js
@@ -1,0 +1,16 @@
+import { initFlatpickr } from "../plugins/flatpickr";
+
+const init_add_fields = () => {
+
+  $('.simple_form').on('click', '.add_fields', function(event) {
+    console.log("clicked!")
+    var regexp, time;
+    time = new Date().getTime();
+    regexp = new RegExp($(this).data('id'), 'g');
+    $(this).before($(this).data("fields").replace(regexp, time));
+    event.preventDefault();
+    return initFlatpickr(); // we need to run initFlatpickr plugin after field is added again 
+  });
+}
+
+export { init_add_fields }

--- a/app/javascript/plugins/init_remove_fields.js
+++ b/app/javascript/plugins/init_remove_fields.js
@@ -1,8 +1,7 @@
 const init_remove_fields = () => {
 
   $('.simple_form').on('click', '.remove_fields', function (event) {
-    console.log("clicked!")
-    $(this).prev('input[type="hidden"]').val('1');
+    $(this).prev().find('input[type=hidden]').val('true');
     $(this).closest('.fields').hide();
     return event.preventDefault();
   });

--- a/app/javascript/plugins/init_remove_fields.js
+++ b/app/javascript/plugins/init_remove_fields.js
@@ -1,0 +1,11 @@
+const init_remove_fields = () => {
+
+  $('.simple_form').on('click', '.remove_fields', function (event) {
+    console.log("clicked!")
+    $(this).prev('input[type="hidden"]').val('1');
+    $(this).closest('.fields').hide();
+    return event.preventDefault();
+  });
+}
+
+export { init_remove_fields }

--- a/app/javascript/plugins/init_remove_fields.js
+++ b/app/javascript/plugins/init_remove_fields.js
@@ -1,8 +1,12 @@
 const init_remove_fields = () => {
 
   $('.simple_form').on('click', '.remove_fields', function (event) {
+    // choice instance needs to be destoryed
     $(this).prev().find('input[type=hidden]').val('true');
+
+    // choice fields need to be removed
     $(this).closest('.fields').hide();
+
     return event.preventDefault();
   });
 }

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -2,7 +2,7 @@ class Meeting < ApplicationRecord
   # References
   belongs_to :user
   has_many :choices, dependent: :destroy
-  accepts_nested_attributes_for :choices, allow_destroy: true
+  accepts_nested_attributes_for :choices, reject_if: :all_blank, allow_destroy: true
 
   # Validations
   validates :start_datetime, :end_datetime, presence: true

--- a/app/views/meetings/_choice_fields.html.erb
+++ b/app/views/meetings/_choice_fields.html.erb
@@ -1,7 +1,9 @@
 <%# Choice fields for simple form %>
 
-<%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-<%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-<%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
-<%= f.check_box :_destroy %>
-<%= f.label :_destroy, "Remove Choice" %>
+<div class="fields col-3">
+  <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+  <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+  <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
+  <%= f.input :_destroy, as: :hidden %>
+  <%= link_to "Remove Choice", "javascript:void(0)", class: "remove_fields" %>
+</div>

--- a/app/views/meetings/_choice_fields.html.erb
+++ b/app/views/meetings/_choice_fields.html.erb
@@ -1,9 +1,11 @@
-<%# Choice fields for simple form %>
+<%# ---------- Choice fields for simple form ---------- %>
 
-<div class="fields col-3">
+<div class="fields col-4 mt-3">
   <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
   <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
   <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
+
+  <%# Hidden field to destory choice instance + link for event listener %>
   <%= f.input :_destroy, as: :hidden %>
   <%= link_to "Remove Choice", "javascript:void(0)", class: "remove_fields" %>
 </div>

--- a/app/views/meetings/_choice_fields.html.erb
+++ b/app/views/meetings/_choice_fields.html.erb
@@ -1,4 +1,4 @@
-<%# Choice fields %>
+<%# Choice fields for simple form %>
 
 <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
 <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>

--- a/app/views/meetings/_choice_fields.html.erb
+++ b/app/views/meetings/_choice_fields.html.erb
@@ -1,0 +1,7 @@
+<%# Choice fields %>
+
+<%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+<%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+<%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
+<%= f.check_box :_destroy %>
+<%= f.label :_destroy, "Remove Choice" %>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -24,9 +24,7 @@
         <%# Choices form %>
         <%= f.simple_fields_for :choices do |f| %>
           <div class= "col-3">
-            <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-            <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-            <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
+            <%= render "choice_fields", f: f %>
           </div>
         <% end %>
       </div>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -5,14 +5,14 @@
       <h5>Create a new meeting:</h5>
     </div>
     <div class="col-9">
-      <h5>Options:</h5>
+      <h5>Choices:</h5>
     </div>
   </div>
 
   <%# ------- FORM FOR CREATING MEETING INVITE ------- %>
   <div>
     <%= simple_form_for @meeting do |f| %>
-      <div class="row">
+      <div class="justify-content-center">
         <%# For original invite %>
         <div class="col-3">
           <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
@@ -22,10 +22,16 @@
 
         <%# Choices form %>
         <%= f.simple_fields_for :choices do |f| %>
-          <div class= "col-3">
+
+          <div>
             <%= render "choice_fields", f: f %>
           </div>
+
         <% end %>
+
+          <%# Method to add fields (application helper) %>
+          <%= link_to_add_fields "Add Choice", f, :choices %>
+
       </div>
 
       <%# Div for button %>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -1,43 +1,37 @@
 <div class="containter p-5 mt-5">
-  <%# ------- Div for titles ------- %>
-  <div class="row">
-    <div class="col-3">
-      <h5>Create a new meeting:</h5>
-    </div>
-    <div class="col-9">
-      <h5>Choices:</h5>
-    </div>
-  </div>
 
   <%# ------- FORM FOR CREATING MEETING INVITE ------- %>
   <div>
     <%= simple_form_for @meeting do |f| %>
-      <div class="justify-content-center">
-        <%# For original invite %>
-        <div class="col-3">
-          <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-          <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
-          <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
-        </div>
 
-        <%# Choices form %>
+      <%# Original instance which sends google calender invite %>
+      <h5>Create a new meeting:</h5>
+
+      <div class="col-3 mt-3">
+        <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+        <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+        <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
+      </div>
+
+      <hr>
+
+      <%# Choices nested form %>
+      <h5>Add or Remove Choices:</h5>
+
+      <div class= "row">
         <%= f.simple_fields_for :choices do |f| %>
-
-          <div>
-            <%= render "choice_fields", f: f %>
-          </div>
-
+          <%= render "choice_fields", f: f %>
         <% end %>
 
-          <%# Method to add fields (application helper) %>
-          <%= link_to_add_fields "Add Choice", f, :choices %>
-
+        <%# Method to add fields (application helper) %>
+        <%= link_to_add_fields "Add Choice", f, :choices %>
       </div>
 
       <%# Div for button %>
       <div class="text-center">
         <%= f.button :submit, "Create Meeting", class: "btn btn-dark" %>
       </div>
+
     <% end %>
   </div>
 </div>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -15,9 +15,8 @@
       <div class="row">
         <%# For original invite %>
         <div class="col-3">
-          <%= f.input :start_datetime, as: :string, label: "Date", class: "form-control", input_html: {class: "datepicker", name: "date"} %>
-          <%= f.input :start_datetime, as: :string, label: "Start Time", class: "form-control", input_html: {class: "timepicker", name: "start_time"} %>
-          <%= f.input :end_datetime, as: :string, label: "End Time", class: "form-control", input_html: {class: "timepicker", name: "end_time"} %>
+          <%= f.input :start_datetime, as: :string, label: "Start Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
+          <%= f.input :end_datetime, as: :string, label: "End Date Time", class: "form-control", input_html: {class: "datetimepicker"} %>
           <%= f.input :location, as: :text, label: 'Location:', placeholder:"eg. 11B Baker street", class: "form-control" %>
         </div>
 

--- a/app/views/meetings/send_invite.html.erb
+++ b/app/views/meetings/send_invite.html.erb
@@ -3,6 +3,15 @@
     <h3><%= "Confirm your meeting with #{@meeting.user.first_name}" %></h3>
     <br>
     <%= simple_form_for @meeting do |f| %>
+      <div class="row justify-content-center">
+        <%= f.simple_fields_for :choices do |f| %>
+          <div class= "col-3">
+            <%= render "choice_fields", f: f %>
+          </div>
+        <% end %>
+      </div>
+
+
       <%= f.input :invitee_email, as: :string, label: 'Your email', placeholder: "input your email address", class: 'form-control' %>
       <br>
       <center><%= f.button :submit, "Confirm meeting with #{@meeting.user.first_name}", class: "caffiend-btn" %></center>

--- a/app/views/meetings/send_invite.html.erb
+++ b/app/views/meetings/send_invite.html.erb
@@ -2,7 +2,9 @@
   <div class="invite-box">
     <h3><%= "Confirm your meeting with #{@meeting.user.first_name}" %></h3>
     <br>
+
     <%= simple_form_for @meeting do |f| %>
+      <%# Show Choices %>
       <div class="row justify-content-center">
         <%= f.simple_fields_for :choices do |f| %>
           <div class= "col-3">
@@ -11,7 +13,7 @@
         <% end %>
       </div>
 
-
+      <%# Input email & Confirmation %>
       <%= f.input :invitee_email, as: :string, label: 'Your email', placeholder: "input your email address", class: 'form-control' %>
       <br>
       <center><%= f.button :submit, "Confirm meeting with #{@meeting.user.first_name}", class: "caffiend-btn" %></center>


### PR DESCRIPTION
Added nested form with meeting choices. 

1. Meeting choices can be added and removed. 
![image](https://user-images.githubusercontent.com/86636163/148182781-bee021f8-22e2-40d6-8c6a-e926800c7a12.png)
![image](https://user-images.githubusercontent.com/86636163/148182898-1e5c9ef1-c367-40c5-9e6f-338fe44c9e30.png)
![image](https://user-images.githubusercontent.com/86636163/148182941-5d174566-a10b-42a3-81a8-45ff4fcdc357.png)

2.1 If new meeting choice is added, choice instance is instantiated
2.2 If meeting choice is removed, choice instance is destroyed
2.3 If meeting choice is blank, choice instance is not instantiated 
2.4 Test is passed if only choice 1 and choice 3 is instantiated, see below.
![image](https://user-images.githubusercontent.com/86636163/148183246-897850b2-bb17-43f4-bfa2-c05a22ef008e.png)
![image](https://user-images.githubusercontent.com/86636163/148183357-d825c0da-c6cb-431b-8783-b71cfbce2ef3.png)
![image](https://user-images.githubusercontent.com/86636163/148183421-4349fc87-c516-4e9a-bd05-0325530e8684.png)
![image](https://user-images.githubusercontent.com/86636163/148183615-bfd06dc8-0ad1-49cc-83f6-1deaea7b25e0.png)

3. Original meeting invite is retained to send the google calendar invite for now, to be changed in the future.
![image](https://user-images.githubusercontent.com/86636163/148183036-3b44b786-0ea5-4479-92eb-59aac2aec264.png)

